### PR TITLE
Fix/Commit Api/Add `results` instead of `response.data`

### DIFF
--- a/assets/js/api/CommitAPI.js
+++ b/assets/js/api/CommitAPI.js
@@ -7,7 +7,7 @@ import {
 
 export const getCommits = () => axios.get(`/api/commits/`)
   .then((response) => {
-    store.dispatch(getCommitsSuccess({...response.data}));
+    store.dispatch(getCommitsSuccess({...response.data.results}));
   });
 
 export const createRepository = (values, headers, formDispatch) => axios.post('/api/repositories/', values, {headers})


### PR DESCRIPTION
# Fix - Get `response.data.results` instead of `response.data`

## Purpose  
This bug was generated by PR #9 which we've added pagination to `Commit` and now the payload of our response changed

## Modifications
- `assets/js/api/CommitAPI.js`: Get `response.data.results` instead of `response.data`
