### PR TITLE
feat(github api integration): Make repo search be case insensitive

### DIFF
--- a/repositories/views.py
+++ b/repositories/views.py
@@ -33,7 +33,7 @@ class RepositoryCreateView(BaseView):
         elif status_code not in [200, 304]:
             return Response({'error': 'Unknown error.'}, status=status_code)
 
-        if any(repo.data['name'] == repo_name for repo in repositories):
+        if any(repo.data['name'].lower() == repo_name.lower() for repo in repositories):
             serializer = RepositorySerializer(data=request.data)
             serializer.is_valid(raise_exception=True)
             serializer.save()


### PR DESCRIPTION
# Feat - Make repo search be case insensitive

## Purpose 
The goal of this PR is to make the `repository` existence validation to be case insensitive

## Modifications
- `repositories/views.py`: Use `lower()` to handle case insensitive comparison

## Test Coverage
![image](https://github.com/jsobralgitpush/vinta-challenge/assets/63429525/2f30ffe0-fb0e-404e-800a-bfd00ac52043)

## Help Welcome
Always welcome