### PR TITLE
chore(apply autopep8): Apply autopep8 in py files

### DIFF
--- a/githubmonitor/api/github.py
+++ b/githubmonitor/api/github.py
@@ -1,6 +1,7 @@
 import requests
 from decouple import config
 
+
 class Commit:
     def __init__(self, data):
         self.sha = data['sha']
@@ -10,9 +11,11 @@ class Commit:
         self.date = data['commit']['author']['date']
         self.avatar = data['author']['avatar_url'] if data['author'] else None
 
+
 class Repository:
     def __init__(self, data):
         self.data = data
+
 
 class RepositoryService:
 
@@ -21,32 +24,43 @@ class RepositoryService:
             'Authorization': f"token {config('GITHUB_ACCESS_TOKEN')}",
             'Accept': 'application/vnd.github.v3+json'
         }
-    
+
     @staticmethod
     def fetch_by_user(username, params=None):
         url = f'https://api.github.com/users/{username}/repos'
-        response = requests.get(url, headers=RepositoryService().__get_headers(), params=params)
+        response = requests.get(
+            url,
+            headers=RepositoryService().__get_headers(),
+            params=params)
         repositories = [Repository(repo_data) for repo_data in response.json()]
         return response.status_code, repositories
 
     @staticmethod
     def fetch_by_repo_name(username, repo_name, params=None):
         url = f'https://api.github.com/repos/{username}/{repo_name}'
-        response = requests.get(url, headers=RepositoryService().__get_headers(), params=params)
+        response = requests.get(
+            url,
+            headers=RepositoryService().__get_headers(),
+            params=params)
         repository = Repository(response.json())
         return response.status_code, repository
 
     @staticmethod
     def fetch_by_authenticated_user(params=None):
         url = 'https://api.github.com/user/repos'
-        response = requests.get(url, headers=RepositoryService().__get_headers(), params=params)
+        response = requests.get(
+            url,
+            headers=RepositoryService().__get_headers(),
+            params=params)
         repositories = [Repository(repo_data) for repo_data in response.json()]
         return response.status_code, repositories
-    
+
     @staticmethod
     def fetch_repo_commits(username, repo_name, params=None):
         url = f'https://api.github.com/repos/{username}/{repo_name}/commits'
-        response = requests.get(url, headers=RepositoryService().__get_headers(), params=params)
+        response = requests.get(
+            url,
+            headers=RepositoryService().__get_headers(),
+            params=params)
         commits = [Commit(commit_data) for commit_data in response.json()]
         return response.status_code, commits
-    

--- a/githubmonitor/pagination.py
+++ b/githubmonitor/pagination.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 from urllib.parse import urlencode
 
+
 class CustomPageNumberPagination(PageNumberPagination):
     def get_paginated_response(self, data):
         request = self.request
@@ -10,7 +11,10 @@ class CustomPageNumberPagination(PageNumberPagination):
         current_query_params = request.GET.copy()
 
         first_url = self.get_page_url(1, current_url, current_query_params)
-        last_url = self.get_page_url(self.page.paginator.num_pages, current_url, current_query_params)
+        last_url = self.get_page_url(
+            self.page.paginator.num_pages,
+            current_url,
+            current_query_params)
 
         return Response({
             'count': self.page.paginator.count,
@@ -27,11 +31,12 @@ class CustomPageNumberPagination(PageNumberPagination):
         query_string = urlencode(current_query_params)
         base_url = f"{current_url.split('?')[0]}?" if '?' in current_url else f"{current_url}?"
         return f"{base_url}{query_string}"
-    
+
     def paginate_queryset(self, queryset, request, view=None):
         try:
             return super().paginate_queryset(queryset, request, view)
         except NotFound:
-            self.paginator = self.django_paginator_class(queryset, self.page_size)
+            self.paginator = self.django_paginator_class(
+                queryset, self.page_size)
             self.page = self.paginator.page(self.paginator.num_pages)
             return self.page

--- a/githubmonitor/tests/test_pagination.py
+++ b/githubmonitor/tests/test_pagination.py
@@ -6,6 +6,7 @@ from githubmonitor.pagination import CustomPageNumberPagination
 from repositories.models import Commit, Repository
 from repositories.views import CommitListView
 
+
 class CustomPageNumberPaginationTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
@@ -13,12 +14,12 @@ class CustomPageNumberPaginationTestCase(TestCase):
         self.view = CommitListView.as_view()
         self.repository = Repository.objects.create(name='Repo')
 
-        for i in range(50):  
+        for i in range(50):
             Commit.objects.create(
-              author="Pedro",
-              message=f'Commit {i}', 
-              date=timezone.now(), 
-              repository=self.repository
+                author="Pedro",
+                message=f'Commit {i}',
+                date=timezone.now(),
+                repository=self.repository
             )
 
     def test_pagination(self):
@@ -33,9 +34,9 @@ class CustomPageNumberPaginationTestCase(TestCase):
         request = self.factory.get(url)
         request = Request(request)
 
-        queryset = Commit.objects.all()  
+        queryset = Commit.objects.all()
         results = self.pagination.paginate_queryset(queryset, request)
-        self.assertEqual(len(results), 10) 
+        self.assertEqual(len(results), 10)
 
         response = self.pagination.get_paginated_response(results)
         self.assertIn('count', response.data)
@@ -47,9 +48,4 @@ class CustomPageNumberPaginationTestCase(TestCase):
         self.assertIn('results', response.data)
 
         self.assertTrue(response.data['first'].endswith('?page=1'))
-        self.assertTrue(response.data['last'].endswith('?page=5'))  
-
-
-
-
-
+        self.assertTrue(response.data['last'].endswith('?page=5'))

--- a/githubmonitor/tests/test_tasks.py
+++ b/githubmonitor/tests/test_tasks.py
@@ -4,12 +4,17 @@ from repositories.tasks import fetch_and_store_commits
 from repositories.models import Repository, Commit
 from datetime import datetime
 
+
 class TestFetchAndStoreCommitsTask(TestCase):
-    
+
     @patch('repositories.tasks.RepositoryService.fetch_repo_commits')
     @patch('repositories.tasks.Repository.objects.get')
     @patch('repositories.tasks.Commit.objects.create')
-    def test_fetch_and_store_commits(self, mock_commit_create, mock_repo_get, mock_fetch_commits):
+    def test_fetch_and_store_commits(
+            self,
+            mock_commit_create,
+            mock_repo_get,
+            mock_fetch_commits):
         mock_repo = Repository(id=1, name='Test Repo')
         mock_repo_get.return_value = mock_repo
 

--- a/repositories/models.py
+++ b/repositories/models.py
@@ -28,10 +28,13 @@ class Commit(models.Model):
     class Meta:
         ordering = ('-date',)
 
+
 class CommitFilter(django_filters.FilterSet):
     author = django_filters.CharFilter(lookup_expr='icontains')
     repository_id = django_filters.NumberFilter(field_name="repository__id")
-    repository_name = django_filters.CharFilter(field_name="repository__name", lookup_expr='icontains')
+    repository_name = django_filters.CharFilter(
+        field_name="repository__name", lookup_expr='icontains')
+
     class Meta:
         model = Commit
         fields = ['author', 'repository_id', 'repository_name']

--- a/repositories/tasks.py
+++ b/repositories/tasks.py
@@ -9,12 +9,13 @@ from datetime import datetime, timedelta
 def fetch_and_store_commits(username, repo_id):
     repository = Repository.objects.get(id=repo_id)
     since_timestamp = (datetime.now() - timedelta(days=30)).isoformat()
-    status_code, commits = RepositoryService.fetch_repo_commits(username, repository.name, params={'since': since_timestamp})
+    status_code, commits = RepositoryService.fetch_repo_commits(
+        username, repository.name, params={'since': since_timestamp})
 
     if status_code == 200:
 
         for commit in commits:
-            
+
             Commit.objects.create(
                 message=commit.message,
                 sha=commit.sha,

--- a/repositories/urls.py
+++ b/repositories/urls.py
@@ -4,7 +4,16 @@ from .views import CommitListView, RepositoryCreateView, RepositoryListView
 app_name = 'repositories'
 
 urlpatterns = [
-    path('api/commits/', CommitListView.as_view(), name='commits-list'),
-    path('api/repositories/create/', RepositoryCreateView.as_view(), name='repositories-create'),
-    path('api/repositories/list/', RepositoryListView.as_view(), name='repositories-list'),
+    path(
+        'api/commits/',
+        CommitListView.as_view(),
+        name='commits-list'),
+    path(
+        'api/repositories/create/',
+        RepositoryCreateView.as_view(),
+        name='repositories-create'),
+    path(
+        'api/repositories/list/',
+        RepositoryListView.as_view(),
+        name='repositories-list'),
 ]

--- a/repositories/views.py
+++ b/repositories/views.py
@@ -2,15 +2,17 @@ from rest_framework.views import APIView
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from repositories.tasks import fetch_and_store_commits 
+from repositories.tasks import fetch_and_store_commits
 from githubmonitor.api.github import RepositoryService
 from .models import Commit, CommitFilter, Repository
 from .serializers import CommitSerializer, RepositorySerializer
 from githubmonitor.pagination import CustomPageNumberPagination
 
+
 class BaseView(APIView):
     permission_classes = [IsAuthenticated]
-    
+
+
 class CommitListView(BaseView):
 
     def get(self, request):
@@ -20,33 +22,39 @@ class CommitListView(BaseView):
         context = paginator.paginate_queryset(filters.qs, request)
         serializer = CommitSerializer(context, many=True)
         return paginator.get_paginated_response(serializer.data)
-    
+
+
 class RepositoryListView(BaseView):
 
     def get(self, request):
         repositories = Repository.objects.all()
         serializer = RepositorySerializer(repositories, many=True)
         return Response(serializer.data)
-    
+
+
 class RepositoryCreateView(BaseView):
 
     def post(self, request):
         repo_name = request.data.get('name')
         status_code, repositories = RepositoryService.fetch_by_authenticated_user()
         user = request.user
-        
+
         if status_code in [401, 403]:
-            return Response({'error': 'Unauthorized or forbidden.'}, status=status_code)
+            return Response(
+                {'error': 'Unauthorized or forbidden.'}, status=status_code)
         elif status_code == 422:
-            return Response({'error': 'Unprocessable Entity.'}, status=status_code)
+            return Response({'error': 'Unprocessable Entity.'},
+                            status=status_code)
         elif status_code not in [200, 304]:
             return Response({'error': 'Unknown error.'}, status=status_code)
 
-        if any(repo.data['name'].lower() == repo_name.lower() for repo in repositories):
+        if any(repo.data['name'].lower() == repo_name.lower()
+               for repo in repositories):
             serializer = RepositorySerializer(data=request.data)
             serializer.is_valid(raise_exception=True)
             serializer.save()
             fetch_and_store_commits.delay(user.username, serializer.data['id'])
             return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-        return Response({'error': 'Repository does not exist.'}, status=status.HTTP_404_NOT_FOUND)
+        return Response({'error': 'Repository does not exist.'},
+                        status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
# Chore: Apply `autopep8` into `.py` files

## Purpose
This goal of this PR is to apply `PEP8` patterns into our `.py` files. To do it, we are using `autpep8` [lib](https://pypi.org/project/autopep8/) by running `autopep8 --in-place --aggressive --aggressive --recursive .`


- `--in-place`: This argument is used to make changes to files in place. It means that autopep8 will modify the original files directly, instead of just displaying the diff of the changes.
- `--aggressive`: This option makes `autopep8` more aggressive about fixing issues. This can potentially make changes to the code that might change its meaning slightly, or introduce bugs, but generally it should be safe to use. In your command, --aggressive is specified twice, which makes `autopep8` even more aggressive about making changes. This might, for example, cause it to change code like ''.join(['a', 'b', 'c']) into ''.join('abc').
- `--recursive`: This option tells `autopep8` to recursively go through directories and subdirectories to find all .py files and apply the formatting rules to them.

## Modifications
All the modifications were made by `autopep8` command

## Test Coverage
![image](https://github.com/jsobralgitpush/vinta-challenge/assets/63429525/06dd5757-6246-49ec-b319-a4792ece94e0)
