### PR TITLE
chore(workflows): Add bandit scan workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,21 @@
+name: Bandit Security Scan
+
+on: [push, pull_request]
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    name: Bandit Security Scan
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit
+      - name: Run Bandit
+        run: bandit -r .


### PR DESCRIPTION
# Chore: Add `bandit` scan into our workflow 

## Purpose
As we told in PR #25, `bandit` is great to look for `OWASP top ten` flaws. Add a github action to it 