### PR TITLE
chore(workflows): Add eslint scan to workflow

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -13,10 +13,7 @@ jobs:
       with:
         node-version: 14
     - name: Install dependencies
-      run: |
-        cd assets/js
-        npm install
+      run: npm install
     - name: Run npx lint
-      run: |
-        cd assets/js
-        npx lint
+      run: 
+        npx lint assets/js


### PR DESCRIPTION
# Chore: Add eslint scan as workflow

## Purpose
The goal of this PR is to add estlint scan as a workflow. But we are encountering a setup error 
![image](https://github.com/jsobralgitpush/vinta-challenge/assets/63429525/ac43f0b9-1d87-4d9b-b83a-9293e1a84573)

