### PR TITLE
Refactor/components/use react hooks

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,6 +1,6 @@
 name: eslint-airbnb
 
-on: [push, pull_request]
+# on: [push, pull_request]
 
 jobs:
   npx-lint:

--- a/assets/js/__tests__/components/RepoList/index.test.js
+++ b/assets/js/__tests__/components/RepoList/index.test.js
@@ -27,7 +27,7 @@ describe('RepoList', () => {
   it('handles repository click correctly', () => {
     render(<RepoList repos={mockData} />);
 
-    fireEvent.click(screen.getByText('repo-one').parentElement);
+    fireEvent.click(screen.getByText('repo-one'));
 
     expect(getCommits).toHaveBeenCalledWith('/api/commits/?repository_name=repo-one');
   });

--- a/assets/js/components/CommitList/index.js
+++ b/assets/js/components/CommitList/index.js
@@ -25,7 +25,7 @@ function CommitList(props) {
 
             <div className="card-body">
               {commits.map((commit, index) => (
-                <div key={`${commit.sha}-${index}`}>
+                <div key={`${commit.sha}`}>
                   <div className="avatar">
                     <img alt={commit.author} className="img-author" src={commit.avatar} />
                   </div>
@@ -34,31 +34,43 @@ function CommitList(props) {
                       {commit.message}
                     </p>
                     <small className="text-muted">
-                      <a
-                        role="button"
-                        href="#"
-                        onClick={(event) => {
-                          event.preventDefault();
-                          handleAuthorClick(commit.author);
+                      <button
+                        type="button"
+                        onClick={() => handleAuthorClick(commit.author)}
+                        style={{
+                          backgroundColor: 'transparent',
+                          color: 'blue',
+                          border: 'none',
+                          cursor: 'pointer',
+                          textDecoration: 'underline',
+                          display: 'inline',
+                          margin: 0,
+                          padding: 0,
                         }}
                       >
                         {commit.author}
-                      </a>
+                      </button>
                       {' '}
                       authored
                       {' '}
                       on
                       {' '}
-                      <a
-                        role="button"
-                        href="#"
-                        onClick={(event) => {
-                          event.preventDefault();
-                          handleRepoClick(commit.repository);
+                      <button
+                        type="button"
+                        onClick={() => handleRepoClick(commit.repository)}
+                        style={{
+                          backgroundColor: 'transparent',
+                          color: 'blue',
+                          border: 'none',
+                          cursor: 'pointer',
+                          textDecoration: 'underline',
+                          display: 'inline',
+                          margin: 0,
+                          padding: 0,
                         }}
                       >
                         {commit.repository}
-                      </a>
+                      </button>
                       {' '}
                       at
                       {' '}
@@ -77,7 +89,16 @@ function CommitList(props) {
 }
 
 CommitList.propTypes = {
-  commits: PropTypes.arrayOf(PropTypes.object).isRequired,
+  commits: PropTypes.arrayOf(
+    PropTypes.shape({
+      sha: PropTypes.string,
+      author: PropTypes.string,
+      avatar: PropTypes.string,
+      message: PropTypes.string,
+      repository: PropTypes.string,
+      date: PropTypes.string,
+    }),
+  ).isRequired,
 };
 
 export default CommitList;

--- a/assets/js/components/RepoList/index.js
+++ b/assets/js/components/RepoList/index.js
@@ -14,7 +14,7 @@ function RepoList({ repos }) {
         <li key={repo.id}>
           <button
             type="button"
-            onClick={() => handleRepoClick(repo.repository)}
+            onClick={() => handleRepoClick(repo.name)}
             key={repo.id}
             style={{
               backgroundColor: 'transparent',

--- a/assets/js/components/RepoList/index.js
+++ b/assets/js/components/RepoList/index.js
@@ -11,25 +11,25 @@ function RepoList({ repos }) {
   return (
     <ul>
       {repos.map((repo) => (
-        <button
-          type="button"
-          onClick={() => handleRepoClick(repo.repository)}
-          style={{
-            backgroundColor: 'transparent',
-            color: 'blue',
-            border: 'none',
-            cursor: 'pointer',
-            textDecoration: 'underline',
-            display: 'inline',
-            margin: 0,
-            padding: 0,
-          }}
-          key={repo.id}
-        >
-          <li>
+        <li key={repo.id}>
+          <button
+            type="button"
+            onClick={() => handleRepoClick(repo.repository)}
+            key={repo.id}
+            style={{
+              backgroundColor: 'transparent',
+              color: 'blue',
+              border: 'none',
+              cursor: 'pointer',
+              textDecoration: 'underline',
+              display: 'inline',
+              margin: 0,
+              padding: 0,
+            }}
+          >
             {repo.name}
-          </li>
-        </button>
+          </button>
+        </li>
       ))}
     </ul>
   );

--- a/assets/js/components/RepoList/index.js
+++ b/assets/js/components/RepoList/index.js
@@ -11,19 +11,25 @@ function RepoList({ repos }) {
   return (
     <ul>
       {repos.map((repo) => (
-        <a
-          role="button"
-          href="#"
-          onClick={(event) => {
-            event.preventDefault();
-            handleRepoClick(repo.name);
+        <button
+          type="button"
+          onClick={() => handleRepoClick(repo.repository)}
+          style={{
+            backgroundColor: 'transparent',
+            color: 'blue',
+            border: 'none',
+            cursor: 'pointer',
+            textDecoration: 'underline',
+            display: 'inline',
+            margin: 0,
+            padding: 0,
           }}
           key={repo.id}
         >
           <li>
             {repo.name}
           </li>
-        </a>
+        </button>
       ))}
     </ul>
   );

--- a/assets/js/containers/CommitListContainer.js
+++ b/assets/js/containers/CommitListContainer.js
@@ -1,14 +1,11 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 import * as commitAPI from '../api/CommitAPI';
 import CommitList from '../components/CommitList';
 import PaginationComponent from '../components/Utils/PaginationComponent';
 
-const CommitListContainer = () => {
-  const commits = useSelector(state => state.commitState.commits);
-  const pageData = useSelector(state => state.commitState.pageData);
-
+const CommitListContainer = ({commits, pageData}) => {
   useEffect(() => {
     commitAPI.getCommits('/api/commits/');
   }, []); 
@@ -26,4 +23,9 @@ CommitListContainer.propTypes = {
   pageData: PropTypes.object.isRequired,
 };
 
-export default CommitListContainer;
+const mapStateToProps = (store) => ({
+  commits: store.commitState.commits,
+  pageData: store.commitState.pageData,
+});
+
+export default connect(mapStateToProps)(CommitListContainer);

--- a/assets/js/containers/CommitListContainer.js
+++ b/assets/js/containers/CommitListContainer.js
@@ -1,24 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import * as commitAPI from '../api/CommitAPI';
 import CommitList from '../components/CommitList';
 import PaginationComponent from '../components/Utils/PaginationComponent';
 
-class CommitListContainer extends React.Component {
-  componentDidMount() {
-    commitAPI.getCommits('/api/commits/');
-  }
+const CommitListContainer = () => {
+  const commits = useSelector(state => state.commitState.commits);
+  const pageData = useSelector(state => state.commitState.pageData);
 
-  render() {
-    const { commits, pageData } = this.props;
-    return (
-      <div>
-        <CommitList commits={commits} />
-        <PaginationComponent pageData={pageData} />
-      </div>
-    );
-  }
+  useEffect(() => {
+    commitAPI.getCommits('/api/commits/');
+  }, []); 
+
+  return (
+    <div>
+      <CommitList commits={commits} />
+      <PaginationComponent pageData={pageData} />
+    </div>
+  );
 }
 
 CommitListContainer.propTypes = {
@@ -26,9 +26,4 @@ CommitListContainer.propTypes = {
   pageData: PropTypes.object.isRequired,
 };
 
-const mapStateToProps = (store) => ({
-  commits: store.commitState.commits,
-  pageData: store.commitState.pageData,
-});
-
-export default connect(mapStateToProps)(CommitListContainer);
+export default CommitListContainer;

--- a/assets/js/containers/RepoCreateContainer.js
+++ b/assets/js/containers/RepoCreateContainer.js
@@ -1,22 +1,21 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import * as commitAPI from '../api/CommitAPI';
 import Form from '../components/RepoCreateForm';
 
-class RepoCreateContainer extends React.Component {
-  submit = (values, dispatch) => {
+const RepoCreateContainer = ({errorMessage, successMessage}) => {
+  const dispatch = useDispatch();
+
+  const submit = useCallback((values) => {
     const token = document.getElementById('main').dataset.csrftoken;
     const name = values.name.split('/')[1];
     const v = { ...values, name };
     return commitAPI.createRepository(v, { 'X-CSRFToken': token }, dispatch);
-  };
+  }, [dispatch]);
 
-  render() {
-    const { successMessage, errorMessage } = this.props;
-    return <Form onSubmit={this.submit} successMessage={successMessage} errorMessage={errorMessage} />;
-  }
-}
+  return <Form onSubmit={submit} successMessage={successMessage} errorMessage={errorMessage} />;
+};
 
 RepoCreateContainer.propTypes = {
   successMessage: PropTypes.bool.isRequired,
@@ -24,8 +23,8 @@ RepoCreateContainer.propTypes = {
 };
 
 const mapStateToProps = (store) => ({
-  successMessage: store.commitState.successMessage,
   errorMessage: store.commitState.errorMessage,
+  successMessage: store.commitState.successMessage,
 });
 
 export default connect(mapStateToProps)(RepoCreateContainer);

--- a/assets/js/containers/RepoListContainer.js
+++ b/assets/js/containers/RepoListContainer.js
@@ -1,22 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import * as commitAPI from '../api/CommitAPI';
 import RepoList from '../components/RepoList/index';
 
-class RepoListContainer extends React.Component {
-  componentDidMount() {
+function RepoListContainer({ repos }) {
+  useEffect(() => {
     commitAPI.getRepos();
-  }
+  }, []);
 
-  render() {
-    const { repos } = this.props;
-    return (
-      <div>
-        <RepoList repos={repos} />
-      </div>
-    );
-  }
+  return (
+    <div>
+      <RepoList repos={repos} />
+    </div>
+  );
 }
 
 RepoListContainer.propTypes = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^0.27.2",
+        "prop-types": "^15.8.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-redux": "^7.2.9",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/vintasoftware/github-monitor#readme",
   "dependencies": {
     "axios": "^0.27.2",
+    "prop-types": "^15.8.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^7.2.9",


### PR DESCRIPTION
# Refactor: Use react hooks on Containers components

## Purpose
The goal of this PR is to use only react hooks as a frontend pattern.

## Modifications
- `.github/workflows/eslint.yml`: Comment `on` to prevent billing from github action
- `assets/js/__tests__/components/RepoList/index.test.js`: Fix test removing `parentElement`
- `assets/js/components/CommitList/index.js`: Fix code based on `eslint`
- `assets/js/components/RepoList/index.js`: Fix code based on `eslint`
- `assets/js/containers/CommitListContainer.js`: Refactor component using react hooks
- `assets/js/containers/RepoCreateContainer.js`: Refactor component using react hooks
- `assets/js/containers/RepoListContainer.js`: Refactor component using react hooks
- `package.json`: Add `prop-types` as `eslint` recommendation

## Test Coverage
![image](https://github.com/jsobralgitpush/vinta-challenge/assets/63429525/1aaa0def-ab81-4707-bdb6-4ef4f5230e63)

## Help Welcome
Always Welcome!

